### PR TITLE
Add AddAllStepsClassesAsScoped extension method

### DIFF
--- a/GherkinSpec.TestAdapter.UnitTests/GherkinSpec.TestAdapter.UnitTests.csproj
+++ b/GherkinSpec.TestAdapter.UnitTests/GherkinSpec.TestAdapter.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -25,8 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/GherkinSpec.TestAdapter/GherkinSpec.TestAdapter.csproj
+++ b/GherkinSpec.TestAdapter/GherkinSpec.TestAdapter.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>GivePenny.GherkinSpec.TestAdapter</PackageId>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>0.0.91-alpha</Version>
+    <Version>0.0.93-alpha</Version>
     <Authors>GivePenny</Authors>
     <Company>GivePenny</Company>
     <Product>GherkinSpec</Product>

--- a/GherkinSpec.TestModel.UnitTests/GherkinSpec.TestModel.UnitTests.csproj
+++ b/GherkinSpec.TestModel.UnitTests/GherkinSpec.TestModel.UnitTests.csproj
@@ -1,23 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Resources/*.feature" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GherkinSpec.Model\GherkinSpec.Model.csproj" />
+    <ProjectReference Include="..\GherkinSpec.TestModel\GherkinSpec.TestModel.csproj" />
   </ItemGroup>
 
 </Project>

--- a/GherkinSpec.TestModel.UnitTests/Samples/StepBindingInstanceSamples.cs
+++ b/GherkinSpec.TestModel.UnitTests/Samples/StepBindingInstanceSamples.cs
@@ -1,0 +1,11 @@
+﻿namespace GherkinSpec.TestModel.UnitTests.Samples
+{
+    [Steps]
+    public class StepBindingInstanceSamples
+    {
+        [Given("a plain (.+) in a non-static method")]
+        public void GivenANonStaticPlainTextMatch(string value)
+        {
+        }
+    }
+}

--- a/GherkinSpec.TestModel.UnitTests/Samples/StepBindingStaticSamples.cs
+++ b/GherkinSpec.TestModel.UnitTests/Samples/StepBindingStaticSamples.cs
@@ -1,0 +1,11 @@
+﻿namespace GherkinSpec.TestModel.UnitTests.Samples
+{
+    [Steps]
+    public static class StepBindingStaticSamples
+    {
+        [Given("a plain (.+) in a non-static method")]
+        public static void GivenANonStaticPlainTextMatch(string value)
+        {
+        }
+    }
+}

--- a/GherkinSpec.TestModel.UnitTests/ServiceCollectionExtensionsShould.cs
+++ b/GherkinSpec.TestModel.UnitTests/ServiceCollectionExtensionsShould.cs
@@ -1,0 +1,29 @@
+﻿using GherkinSpec.TestModel.UnitTests.Samples;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace GherkinSpec.TestModel.UnitTests
+{
+    [TestClass]
+    public class ServiceCollectionExtensionsShould
+    {
+        [TestMethod]
+        public void RegisterAllNonStaticStepsClassesInCallingAssembly()
+        {
+            var services = new ServiceCollection();
+            services.AddAllStepsClassesAsScoped();
+
+            Assert.AreEqual(1, services.Count(descriptor => descriptor.ServiceType == typeof(StepBindingInstanceSamples)));
+        }
+
+        [TestMethod]
+        public void DoesNotRegisterStaticStepsClasses()
+        {
+            var services = new ServiceCollection();
+            services.AddAllStepsClassesAsScoped();
+
+            Assert.AreEqual(0, services.Count(descriptor => descriptor.ServiceType == typeof(StepBindingStaticSamples)));
+        }
+    }
+}

--- a/GherkinSpec.TestModel/GherkinSpec.TestModel.csproj
+++ b/GherkinSpec.TestModel/GherkinSpec.TestModel.csproj
@@ -1,7 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+  </ItemGroup>
 
 </Project>

--- a/GherkinSpec.TestModel/ServiceCollectionExtensions.cs
+++ b/GherkinSpec.TestModel/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace GherkinSpec.TestModel
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddAllStepsClassesAsScoped(this IServiceCollection services)
+            => AddAllStepsClassesAsScoped(services, Assembly.GetCallingAssembly());
+
+        public static IServiceCollection AddAllStepsClassesAsScoped(this IServiceCollection services, Assembly assembly)
+        {
+            foreach (var type in StepsClasses
+                .FindIn(assembly)
+                .Where(IsNotStaticOrAbstract))
+            {
+                services.AddScoped(type);
+            }
+
+            return services;
+        }
+
+        // Static classes are both abstract and sealed.  We want neither abstract nor static.
+        // https://stackoverflow.com/questions/2639418/use-reflection-to-get-a-list-of-static-classes
+        private static bool IsNotStaticOrAbstract(Type type)
+            => !type.IsAbstract;
+    }
+}

--- a/GherkinSpec.TestModel/StepsClasses.cs
+++ b/GherkinSpec.TestModel/StepsClasses.cs
@@ -1,13 +1,12 @@
-﻿using GherkinSpec.TestModel;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace GherkinSpec.TestAdapter.Binding
+namespace GherkinSpec.TestModel
 {
-    static class StepsClasses
+    public static class StepsClasses
     {
         // Test runners use an isolated appdomain so the cache can be static as it will be discarded after each test run or when the assembly
         // is changed and re-built.

--- a/GherkinSpec.sln
+++ b/GherkinSpec.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{288CE073-1
 		docs\Steps.md = docs\Steps.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GherkinSpec.TestModel.UnitTests", "GherkinSpec.TestModel.UnitTests\GherkinSpec.TestModel.UnitTests.csproj", "{B4DFA6C9-4DED-4E76-8FFE-27AD4EA9D5F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{9B13EDC5-80AD-4C6B-8117-BF6E04177CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B13EDC5-80AD-4C6B-8117-BF6E04177CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B13EDC5-80AD-4C6B-8117-BF6E04177CE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4DFA6C9-4DED-4E76-8FFE-27AD4EA9D5F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4DFA6C9-4DED-4E76-8FFE-27AD4EA9D5F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4DFA6C9-4DED-4E76-8FFE-27AD4EA9D5F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4DFA6C9-4DED-4E76-8FFE-27AD4EA9D5F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/DependencyInjection.md
+++ b/docs/DependencyInjection.md
@@ -24,6 +24,8 @@ This is probably the most useful lifetime mode for steps classes and shared data
 
 One test run containing several tests will create several instances of scoped classes, each one isolated and available only to one test.
 
+All classes marked with `[Steps]` within the current test project can be automatically detected and registered with a Scoped lifetime using the `.AddAllStepsClassesAsScoped()` extension method.
+
 #### Singleton
 
 Singleton instances are dedicated to the entire test run.  One instance is shared between all tests.


### PR DESCRIPTION
Implements #20 

Requires all test projects to tolerate a reference to Microsoft.Extensions.DependencyInjection.Abstractions but assemblies from that package were loaded in anyway when the tests execute (due to service-scope support needed inside the TestAdapter).

ComplexExample repo will be slightly updated when this PR is merged to master.