### PR TITLE
Catch early exceptions in test runs, try to avoid hang in VS UI

### DIFF
--- a/GherkinSpec.TestAdapter.UnitTests.ReferencedAssembly/GlobalSuppressions.cs
+++ b/GherkinSpec.TestAdapter.UnitTests.ReferencedAssembly/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Many methods used in unit tests require parameters to provoke method-binding scenarios in the subject under test but the methods themselves don't use the parameters.")]

--- a/GherkinSpec.TestAdapter.UnitTests/Binding/StepBinderShould.cs
+++ b/GherkinSpec.TestAdapter.UnitTests/Binding/StepBinderShould.cs
@@ -10,8 +10,6 @@ namespace GherkinSpec.TestAdapter.UnitTests.Binding
     [TestClass]
     public class StepBinderShould
     {
-        private readonly Mock<IMessageLogger> mockLogger = new Mock<IMessageLogger>();
-
         [TestMethod]
         public void FindMethodWithPlainTextGiven()
         {

--- a/GherkinSpec.TestAdapter.UnitTests/GlobalSuppressions.cs
+++ b/GherkinSpec.TestAdapter.UnitTests/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Many methods used in unit tests require parameters to provoke method-binding scenarios in the subject under test but the methods themselves don't use the parameters.")]

--- a/GherkinSpec.TestAdapter.UnitTests/SourceFileLocatorShould.cs
+++ b/GherkinSpec.TestAdapter.UnitTests/SourceFileLocatorShould.cs
@@ -9,8 +9,6 @@ namespace GherkinSpec.TestAdapter.UnitTests
     [TestClass]
     public class SourceFileLocatorShould
     {
-        private readonly Mock<IMessageLogger> mockLogger = new Mock<IMessageLogger>();
-
         [TestMethod]
         public void FindFeatureFileWithFeatureExtension()
             => FindFeatureFileWithExtension("feature");
@@ -44,8 +42,7 @@ namespace GherkinSpec.TestAdapter.UnitTests
                 .Single();
 
             return locator.FindFeatureFileNameIfPossible(
-                resourceNameToFind,
-                mockLogger.Object);
+                resourceNameToFind);
         }
 
         [TestMethod]

--- a/GherkinSpec.TestAdapter/Binding/StepBinder.cs
+++ b/GherkinSpec.TestAdapter/Binding/StepBinder.cs
@@ -124,7 +124,7 @@ namespace GherkinSpec.TestAdapter.Binding
             var methodHasTableArgument = parameters.Length > 0
                 && parameters.Last().ParameterType == typeof(DataTable);
 
-            ThrowIfExpectsTableButNoneProvided(step, method, parameters, methodHasTableArgument);
+            ThrowIfExpectsTableButNoneProvided(step, method, methodHasTableArgument);
             ThrowIfTableProvidedButNoneExpected(step, method, methodHasTableArgument);
             ThrowIfNotEnoughParametersProvided(step, stepArguments, method, parameters, methodHasTableArgument);
 
@@ -145,7 +145,7 @@ namespace GherkinSpec.TestAdapter.Binding
             return typedValues.ToArray();
         }
 
-        private static void ThrowIfExpectsTableButNoneProvided(IStep step, MethodInfo method, ParameterInfo[] parameters, bool methodHasTableArgument)
+        private static void ThrowIfExpectsTableButNoneProvided(IStep step, MethodInfo method, bool methodHasTableArgument)
         {
             if (methodHasTableArgument && step.TableArgument.IsEmpty)
             {

--- a/GherkinSpec.TestAdapter/Execution/RunHooks.cs
+++ b/GherkinSpec.TestAdapter/Execution/RunHooks.cs
@@ -25,7 +25,7 @@ namespace GherkinSpec.TestAdapter.Execution
             {
                 foreach (var method in FindMethodsWithAttribute<BeforeRunAttribute>(stepsClass))
                 {
-                    await ExecuteMethod(stepsClass, method, nameof(BeforeRunAttribute))
+                    await ExecuteMethod(stepsClass, method)
                         .ConfigureAwait(false);
                 }
             }
@@ -43,7 +43,7 @@ namespace GherkinSpec.TestAdapter.Execution
             {
                 foreach (var method in FindMethodsWithAttribute<AfterRunAttribute>(stepsClass))
                 {
-                    await ExecuteMethod(stepsClass, method, nameof(AfterRunAttribute))
+                    await ExecuteMethod(stepsClass, method)
                         .ConfigureAwait(false);
                 }
             }
@@ -55,7 +55,7 @@ namespace GherkinSpec.TestAdapter.Execution
                 .GetMethods(BindingFlags.FlattenHierarchy | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance)
                 .Where(method => method.GetCustomAttributes<TAttribute>(true).Any());
 
-        private async Task ExecuteMethod(Type type, MethodInfo method, string attributeName)
+        private async Task ExecuteMethod(Type type, MethodInfo method)
         {
             var parameters = method.GetParameters();
 

--- a/GherkinSpec.TestAdapter/SourceFileLocator.cs
+++ b/GherkinSpec.TestAdapter/SourceFileLocator.cs
@@ -14,7 +14,7 @@ namespace GherkinSpec.TestAdapter
             this.assemblyDllPath = assemblyDllPath;
         }
 
-        public TestSourceFile FindFeatureFileNameIfPossible(string resourceName, IMessageLogger logger)
+        public TestSourceFile FindFeatureFileNameIfPossible(string resourceName)
         {
             var folderName = assemblyDllPath;
 

--- a/GherkinSpec.TestAdapter/TestCaseExtensions.cs
+++ b/GherkinSpec.TestAdapter/TestCaseExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace GherkinSpec.TestAdapter
 {
@@ -6,5 +7,28 @@ namespace GherkinSpec.TestAdapter
     {
         public static DiscoveredTestData DiscoveredData(this TestCase testCase)
             => (DiscoveredTestData)testCase.LocalExtensionData;
+
+        public static void MarkAsFailed(this TestCase testCase, IFrameworkHandle frameworkHandle, string errorMessage, string errorStackTrace)
+            => frameworkHandle.RecordResult(
+                new TestResult(testCase)
+                {
+                    Outcome = TestOutcome.Failed,
+                    ErrorMessage = errorMessage,
+                    ErrorStackTrace = errorStackTrace
+                });
+
+        public static void MarkAsSkipped(this TestCase testCase, IFrameworkHandle frameworkHandle)
+            => frameworkHandle.RecordResult(
+                new TestResult(testCase)
+                {
+                    Outcome = TestOutcome.Skipped
+                });
+
+        public static void MarkAsNotFound(this TestCase testCase, IFrameworkHandle frameworkHandle)
+            => frameworkHandle.RecordResult(
+                new TestResult(testCase)
+                {
+                    Outcome = TestOutcome.NotFound
+                });
     }
 }

--- a/GherkinSpec.TestAdapter/TestCasesExtensions.cs
+++ b/GherkinSpec.TestAdapter/TestCasesExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using System.Collections.Generic;
+
+namespace GherkinSpec.TestAdapter
+{
+    static class TestCasesExtensions
+    {
+        public static void TryMarkAsFailed(this IEnumerable<TestCase> testCases, IFrameworkHandle frameworkHandle, string errorMessage, string errorStackTrace)
+        {
+            try
+            {
+                foreach (var testCase in testCases)
+                {
+                    testCase.MarkAsFailed(frameworkHandle, errorMessage, errorStackTrace);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        public static void MarkAsNotFound(this IEnumerable<TestCase> testCases, IFrameworkHandle frameworkHandle)
+        {
+            foreach (var testCase in testCases)
+            {
+                testCase.MarkAsNotFound(frameworkHandle);
+            }
+        }
+    }
+}

--- a/GherkinSpec.TestAdapter/TestDiscoverer.cs
+++ b/GherkinSpec.TestAdapter/TestDiscoverer.cs
@@ -47,7 +47,7 @@ namespace GherkinSpec.TestAdapter
                 var assembly = Assembly.LoadFrom(sourceAssemblyPath);
 
                 // ToArray forces the enumeration to be evaluated so any exceptions are caught and logged fully here.
-                return DiscoverTests(source, assembly, logger).ToArray();
+                return DiscoverTests(source, assembly).ToArray();
             }
             catch (BadImageFormatException exception)
             {
@@ -68,7 +68,7 @@ namespace GherkinSpec.TestAdapter
             return Enumerable.Empty<TestCase>();
         }
 
-        private static IEnumerable<TestCase> DiscoverTests(string source, Assembly assembly, IMessageLogger logger)
+        private static IEnumerable<TestCase> DiscoverTests(string source, Assembly assembly)
         {
             var gherkinParser = new Parser();
             var featureFileLocator = new SourceFileLocator(source);
@@ -84,7 +84,7 @@ namespace GherkinSpec.TestAdapter
 
                 var featureText = ReadResourceText(assembly, resourceName);
                 var feature = gherkinParser.Parse(featureText);
-                var featureSourceFile = featureFileLocator.FindFeatureFileNameIfPossible(resourceName, logger);
+                var featureSourceFile = featureFileLocator.FindFeatureFileNameIfPossible(resourceName);
 
                 var cleanedFeatureFolderAndName = CleanedDotSeparatedName(
                     featureSourceFile,

--- a/GherkinSpec.TestAdapter/TestLogAccessor.cs
+++ b/GherkinSpec.TestAdapter/TestLogAccessor.cs
@@ -8,7 +8,7 @@ namespace GherkinSpec.TestAdapter
 {
     class TestLogAccessor : ITestLogAccessor
     {
-        private AsyncLocal<TestResult> asyncLocalTestResult = new AsyncLocal<TestResult>();
+        private readonly AsyncLocal<TestResult> asyncLocalTestResult = new AsyncLocal<TestResult>();
 
         internal void SetCurrentTestResult(TestResult result)
         {

--- a/GherkinSpec.TestModel.UnitTests/GlobalSuppressions.cs
+++ b/GherkinSpec.TestModel.UnitTests/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Many methods used in unit tests require parameters to provoke method-binding scenarios in the subject under test but the methods themselves don't use the parameters.")]


### PR DESCRIPTION
Exceptions in test setup/teardown methods would cause service tests to suddenly disappear from the Test Explorer in VS, leaving no visual clue that the Test Output window should be checked for details. These new catch blocks instead try to log the exception against each test case, meaning they stay in the UI and appear "red".

On runs with many test cases, VS's Test Explorer UI would sometimes jam in "running" state even though every test case had completed.  We try to avoid that by calling start/finish callbacks on the same thread that VS launched the test run on.

Also includes fixes for code analysis issues highlighted in VS2019.